### PR TITLE
run normcc.R independent of cwd

### DIFF
--- a/MetaCC.py
+++ b/MetaCC.py
@@ -43,6 +43,8 @@ if __name__ == '__main__':
         'min_binsize':150000
     }
 
+    script_directory = os.path.dirname(os.path.abspath(sys.argv[0]))
+
     global_parser = argparse.ArgumentParser(add_help=False)
     global_parser.add_argument('-V', '--version', default=False, action='store_true', help='Show the application version')
     global_parser.add_argument('-v', '--verbose', default=False, action='store_true', help='Verbose output')
@@ -188,7 +190,7 @@ if __name__ == '__main__':
                 
                 from rpy2 import robjects
                 r = robjects.r
-                r.source('NormCC/normcc.R')
+                r.source(f'{script_directory}/NormCC/normcc.R')
                 contig_file = os.path.join(temp_folder , 'contig_info.csv')
                 norm_result = r.normcc(contig_file)
                 
@@ -217,7 +219,7 @@ if __name__ == '__main__':
                 
                 from rpy2 import robjects
                 r = robjects.r
-                r.source('NormCC/normcc_site_free.R')
+                r.source(f'{script_directory}/NormCC/normcc.R')
                 contig_file = os.path.join(temp_folder , 'contig_info.csv')
                 norm_result = r.normcc(contig_file)
                 
@@ -304,7 +306,7 @@ if __name__ == '__main__':
             
             from rpy2 import robjects
             r = robjects.r
-            r.source('NormCC/normcc.R')
+            r.source(f'{script_directory}/NormCC/normcc.R')
             contig_file = 'Test/contig_info_test.csv'
             norm_result = r.normcc(contig_file)
             


### PR DESCRIPTION
Thank you for developing this tool!!
I've been wanting to test HiCBin on my data for a while now, but didn't get to installing it properly.


When running the MetaCC.py script as follows:

```
MetaCCpath=/data/brbloemen/tools/MetaCC
fasta=/data/brbloemen/AMR_transfer_SHIME/COAP/DonorN_CELLS/HiC_workflow/Flye/assembly.fasta
bam=/data/brbloemen/AMR_transfer_SHIME/COAP/DonorN_CELLS/HiC_workflow/hic_sorted.bam

python $MetaCCpath/MetaCC.py norm -e MluCI -e Sau3AI -v $fasta $bam output
```

The following error occurred:
```
INFO     | 2023-10-04 09:10:28,365 | Script.raw_contact | Filtering contigs according to minimal signal(2)...
DEBUG    | 2023-10-04 09:10:28,375 | Script.raw_contact | 263 contigs remain
INFO     | 2023-10-04 09:10:28,391 |    main | Raw contact matrix construction finished
INFO     | 2023-10-04 09:10:28,391 |    main | Begin normalizing raw contacts by NormCC...
WARNING  | 2023-10-04 09:10:28,890 | rpy2.rinterface_lib.callbacks | R[write to console]: Error in file(filename, "r", encoding = encoding) : 
  cannot open the connection

WARNING  | 2023-10-04 09:10:28,891 | rpy2.rinterface_lib.callbacks | R[write to console]: In addition: 
WARNING  | 2023-10-04 09:10:28,891 | rpy2.rinterface_lib.callbacks | R[write to console]: Warning message:

WARNING  | 2023-10-04 09:10:28,891 | rpy2.rinterface_lib.callbacks | R[write to console]: In file(filename, "r", encoding = encoding) :
WARNING  | 2023-10-04 09:10:28,891 | rpy2.rinterface_lib.callbacks | R[write to console]: 
 
WARNING  | 2023-10-04 09:10:28,891 | rpy2.rinterface_lib.callbacks | R[write to console]:  cannot open file 'NormCC/normcc.R': No such file or directory

Traceback (most recent call last):
  File "/data/brbloemen/tools/MetaCC/MetaCC.py", line 191, in <module>
    r.source('NormCC/normcc.R')
  File "/data/brbloemen/mambaforge/envs/MetaCC_env/lib/python3.7/site-packages/rpy2/robjects/functions.py", line 199, in __call__
    .__call__(*args, **kwargs))
  File "/data/brbloemen/mambaforge/envs/MetaCC_env/lib/python3.7/site-packages/rpy2/robjects/functions.py", line 125, in __call__
    res = super(Function, self).__call__(*new_args, **new_kwargs)
  File "/data/brbloemen/mambaforge/envs/MetaCC_env/lib/python3.7/site-packages/rpy2/rinterface_lib/conversion.py", line 45, in _
    cdata = function(*args, **kwargs)
  File "/data/brbloemen/mambaforge/envs/MetaCC_env/lib/python3.7/site-packages/rpy2/rinterface.py", line 677, in __call__
    raise embedded.RRuntimeError(_rinterface._geterrmessage())
rpy2.rinterface_lib.embedded.RRuntimeError: Error in file(filename, "r", encoding = encoding) : 
  cannot open the connection
```

I made a small modification so the NormCC/normcc.R script can be sourced independent of which working directory the MetaCC.py script is run from.